### PR TITLE
Fix proxy and voting scripts

### DIFF
--- a/agora-drep-bench/baseline.csv
+++ b/agora-drep-bench/baseline.csv
@@ -1,6 +1,6 @@
 name,cpu,mem,size
-Benchmarks.GAT V2 Spend,33054770,86203,1478
-Benchmarks.GAT V3 Mint,8015656,23134,1318
+Benchmarks.GAT V2 Spend,33102770,86503,1744
+Benchmarks.GAT V3 Mint,12495383,32746,1584
 Benchmarks.Voting Effect Certify,9134374,29981,1369
 Benchmarks.Voting Effect Spend,30867112,91327,1374
 Benchmarks.Voting Effect Vote,20826069,55198,1367

--- a/agora-drep-spec/Spec/Effects/Voting/Context.hs
+++ b/agora-drep-spec/Spec/Effects/Voting/Context.hs
@@ -85,6 +85,7 @@ spendingContextSpec votingScript =
     testGroup
       "Spending Context tests"
       [ mkTest' "OK case: Valid spending transaction" validSpend ScriptSuccess
+      , mkTest' "Fail case: transaction not burning pGAT" missingGat3Burn ScriptFailure
       , mkTest' "Fail case: transaction missing Authority token" missingGat3Spending ScriptFailure
       ]
 
@@ -221,6 +222,18 @@ validSpend config =
     mconcat
       [ withSpendingUTXO (gat3Utxo config)
       , mint (Value.singleton gat3CurSym (TokenName "") (-1))
+      , input (gat3Utxo config)
+      , vote
+          (DRepVoter (DRepCredential (vsCredential config)))
+          (GovernanceActionId (TxId "") 0)
+          VoteYes
+      ]
+
+missingGat3Burn :: TestConfigVoting -> ScriptContext
+missingGat3Burn config =
+  buildSpending' $
+    mconcat
+      [ withSpendingUTXO (gat3Utxo config)
       , input (gat3Utxo config)
       , vote
           (DRepVoter (DRepCredential (vsCredential config)))

--- a/agora-drep-spec/Spec/Proxy/Context.hs
+++ b/agora-drep-spec/Spec/Proxy/Context.hs
@@ -87,6 +87,7 @@ mintingContextSpec gat3Script =
     testGroup
       "Minting Context tests"
       [ mkTest' "OK case: Valid GAT3 mint" validGAT3Mint ScriptSuccess
+      , mkTest' "OK case: Valid GAT3 burn" validGAT3Burn ScriptSuccess
       , mkTest' "Fail case: Minting without spending own input" mintWithoutSpend ScriptFailure
       ]
 
@@ -202,6 +203,14 @@ validGAT3Mint config =
       , input (gat2Utxo config)
       , mint (Value.singleton (gat3CurSym config) (TokenName "") 1)
       , mint (Value.singleton gat2CurSym (TokenName "") (-1))
+      ]
+
+validGAT3Burn :: TestConfigProxy -> ScriptContext
+validGAT3Burn config =
+  buildMinting' $
+    mconcat
+      [ withMinting (gat3CurSym config)
+      , mint (Value.singleton (gat3CurSym config) (TokenName "") (-1))
       ]
 
 mintWithoutSpend :: TestConfigProxy -> ScriptContext

--- a/agora-drep/Agora/Effects/Voting.hs
+++ b/agora-drep/Agora/Effects/Voting.hs
@@ -198,12 +198,13 @@ votingEffectValidator = plam $ \authSymbol' ctx -> P.do
                   ( \self input rest -> pmatch (pfromData input) $ \case
                       PTxInInfo _ resolved -> P.do
                         PTxOut addr _ datum _ <- pmatch resolved
-                        POutputDatumHash datumHash <- pmatch datum
                         PAddress cred _ <- pmatch addr
                         pmatch cred $ \case
-                          PScriptCredential _ -> pmatch (self # rest) $ \case
-                            PNothing -> pjust # datumHash
-                            PJust _ -> perror
+                          PScriptCredential _ -> P.do
+                            POutputDatumHash datumHash <- pmatch datum
+                            pmatch (self # rest) $ \case
+                              PNothing -> pjust # datumHash
+                              PJust _ -> perror
                           _ -> self # rest
                   )
                   (const (pconstant @(PMaybe (PAsData PDatumHash)) Nothing))

--- a/agora-drep/Agora/Proxy.hs
+++ b/agora-drep/Agora/Proxy.hs
@@ -1,7 +1,7 @@
 -- | @since WIP
 module Agora.Proxy (proxyScript, PProxyDatum (..), ProxyDatum (..)) where
 
-import Agora.Utils (pcountIf, pcurrencySymbolToScriptHash, pscriptHashToCurrencySymbol, psymbolValueOf)
+import Agora.Utils (pcountIf, pcurrencySymbolToScriptHash, pscriptHashToCurrencySymbol)
 import Data.Kind (Type)
 import GHC.Generics qualified as GHC
 import Generics.SOP qualified as SOP
@@ -56,7 +56,6 @@ import Plutarch.Prelude (
   unTermCont,
   (#),
   (#&&),
-  (#||),
   (:-->),
  )
 import Plutarch.Repr.Data (DeriveAsDataRec (DeriveAsDataRec))
@@ -255,15 +254,43 @@ proxyScript = plam $ \authSymbol' ctx -> P.do
                             _ -> pcon PFalse
                     )
 
-            let minted = psymbolValueOf # pfromData currencySymbol # pfromData mint
+            PValue mintAssetMap <- pmatch (pfromData mint)
+            PMap mintAssetList <- pmatch mintAssetMap
+            PCons mintAssetPair1 mintAssetListRest1 <- pmatch mintAssetList
+            let mintCs1 = pfstBuiltin # mintAssetPair1
+            PMap mintTokens1 <- pmatch $ pfromData (psndBuiltin # mintAssetPair1)
+            PCons mintTokenPair1 mintTokens1Rest <- pmatch mintTokens1
+            PNil <- pmatch mintTokens1Rest
 
-            -- Spending Condition 1: Transaction contains an input from Proxy Spending Validator.
-            (minted #== -1)
-              #|| ptraceInfoIfFalse
-                "Transaction must contain an input from Proxy Validator."
-                ( (pcountIf # isValidatorInput # pfromData inputs)
-                    #== 1
-                )
+            -- We have to account for minting and burning scenarios. Minting must
+            -- Minting:
+            --  - must have two asset classes (GAT burn and pGAT mint)
+            --  - rules are enforced in the spending validator
+            -- Burning:
+            --  - must have exactly one asset class (pGAT burn)
+            --  - transaction must contain an input from the Proxy script validator
+            pif
+              (mintCs1 #== currencySymbol)
+              ( pif
+                  (pfromData (psndBuiltin # mintTokenPair1) #== pconstant 1)
+                  ((pcountIf # isValidatorInput # pfromData inputs) #== 1)
+                  ( P.do
+                      PNil <- pmatch mintAssetListRest1
+                      pfromData (psndBuiltin # mintTokenPair1) #== pconstant (-1)
+                  )
+              )
+              ( P.do
+                  PCons mintAssetPair2 mintAssetListRest2 <- pmatch mintAssetListRest1
+                  PNil <- pmatch mintAssetListRest2
+                  let mintCs2 = pfstBuiltin # mintAssetPair2
+                  PMap mintTokens2 <- pmatch $ pfromData (psndBuiltin # mintAssetPair2)
+                  PCons mintTokenPair2 mintTokens2Rest <- pmatch mintTokens2
+                  PNil <- pmatch mintTokens2Rest
+
+                  (mintCs2 #== currencySymbol)
+                    #&& ((pcountIf # isValidatorInput # pfromData inputs) #== 1)
+                    #&& (pfromData (psndBuiltin # mintTokenPair2) #== 1)
+              )
           _ -> perror
 
   pif valid (pcon PUnit) perror

--- a/specification/specification.tex
+++ b/specification/specification.tex
@@ -226,23 +226,24 @@ data Datum = Datum
           \item if \verb|Spending|
                 \begin {itemize}
 
-          \item \verb|ScriptContext| contains exactly 1 script input
-          \item \verb|ScriptContext| contains exactly 1 vote where the \verb|Voter| is the DRep credential of the Voting Script (script hash is common with the spending script)
+          \item Transaction contains exactly 1 script input
+          \item Transaction burns one pGAT (symbol is known from script parameter)
+          \item Transaction contains exactly 1 vote where the \verb|Voter| is the DRep credential of the Voting Script (script hash is common with the spending script)
         \end{itemize}
   \item if \verb|Certifying|
         \begin{itemize}
-          \item \verb|ScriptContext| contains exactly 1 transaction DRep registration certificate
-          \item \verb|ScriptContext| does not contain a vote
-          \item \verb|ScriptContext| does not contain proposal procedures
-          \item \verb|ScriptContext| does not contain treasury donations
+          \item Transaction contains exactly 1 transaction DRep registration certificate
+          \item Transaction does not contain a vote
+          \item Transaction does not contain proposal procedures
+          \item Transaction does not contain treasury donations
         \end{itemize}
   \item if \verb|Voting|
         \begin{itemize}
-          \item above input has \verb|Voting Effect datum| as a hashed datum
-          \item \verb|ScriptContext| contains exactly 1 vote, where the \verb|GovernanceId| and \verb|Vote| match the ones in the \verb|Voting Effect's datum|
-          \item \verb|ScriptContext| does not contain a certificate
-          \item \verb|ScriptContext| does not contain proposal procedures
-          \item \verb|ScriptContext| does not contain treasury donations
+          \item Script input has \verb|Voting Effect datum| as a hashed datum (the spending validator makes sure that we only have 1 script input)
+          \item Transaction contains exactly 1 vote, where the \verb|GovernanceId| and \verb|Vote| match the ones in the \verb|Voting Effect's datum|
+          \item Transaction does not contain a certificate
+          \item Transaction does not contain proposal procedures
+          \item Transaction does not contain treasury donations
         \end{itemize}
 
 


### PR DESCRIPTION
Based on testing results on clarity-backend, I found a few issues:
- proxy GAT couldn't be burnt, and voting spending didn't verify pGAT burn
- datum hash pattern happening too early when traversing inputs, failing unless all inputs have datum hashes
